### PR TITLE
Improve dock position calculation for responsiveness

### DIFF
--- a/packages/app/src/styles/dock.module.css
+++ b/packages/app/src/styles/dock.module.css
@@ -1,6 +1,6 @@
 .dock {
 	position: absolute;
-	bottom: 0;
+	bottom: calc(100vh - 100dvh);
 	left: 50%;
 	transform: translateX(-50%);
 }


### PR DESCRIPTION
Update the dock position calculation to enhance responsiveness across different viewport sizes.

Previously on mobile, the bottom bar would prevent the Dock from showing.